### PR TITLE
Use requestAnimationFrame() instead of CSS animations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The latest changes since last time I pushed something to this repo:
 - Improved the token generation script and released it as a windows .exe
 - Less twitch permissions are now required
 - Better error handing
+- Fixed issues with the scrolling animation
 
 ## List of commands
 

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -161,7 +161,8 @@ function startScrollAnimation() {
     const taskWrapper = document.querySelector(".task-wrapper");
     let taskWrapperHeight = taskWrapper.clientHeight;
 
-    if (taskListHeight > taskWrapperHeight && !scrolling) {
+    if (taskListHeight > taskWrapperHeight) {
+        if (scrolling) return;
         const secondaryTaskList = document.querySelector(".secondary");
         secondaryTaskList.style.display = "flex";
         scrolling = true;
@@ -214,7 +215,10 @@ function infScrollAnimation(time) {
     if (elapsedTime >= duration) {
         primaryTaskList.style.transform = "";
         animationStartTime = null;
-        renderDOM(); // this will restart the animation after the dom is refreshed
+        setTimeout(() => {
+            stopScrollAnimation();
+            renderDOM();
+        }, config.scrollLoopDelaySec * 1000); // this will restart the animation if needed after the dom is refreshed
     } else {
         requestAnimationFrame(infScrollAnimation);
     }


### PR DESCRIPTION
Replaced the use of CSS animations with `requestAnimationFrame()` and manual control over the CSS styles to ensure a smoother animation that doesn't change speed as the task list changes or cause overlaps/gaps. Using this API instead allows for direct control over the animation, meaning the speed and duration can be changed on the fly.

What still needs to be done:
- [x] Re-add support for the `scrollLoopDelaySec` setting.
- [x] Test the code.

Fixes #2