### PR TITLE
feat!: Allow cycling of commands in title

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Inspired by [liyunze-coding/Chat-Task-Tic-Overlay](https://github.com/liyunze-co
 
 The latest changes since last time I pushed something to this repo:
 - Added new settings to give better control over the look of the header.
+- Added a feature to have the commands of the bot cycle in the title. See `settings.js` for details.
 
 ## List of commands
 
@@ -60,7 +61,7 @@ By default everyone can use `help`,  `credits` and `github`, `add` tasks, as wel
 >
 > Last update to `settings.js`: Commit d40c5347872239badb0e8a11d4af2db7f8116547 on Mar 19th, 2024.
 >
-> Last update to `style_settings.css`: Commit a215828d84f31034fae8b3279593d413835a9942 on May 23th, 2024.
+> Last update to `style_settings.css`: Commit 9af7ae1928ffb0949160ddf8e5fb6021e18b40de on May 24th, 2024.
 >
 > Last update to `auth.js`: Commit b807cf384b231e0700130d6f0da875f5604d956b on Oct 18, 2023.
 >

--- a/index.html
+++ b/index.html
@@ -18,8 +18,14 @@
 </head>
 <body>
     <div class="main-content">
-        <div class="header">
-            <div class="title">To Do List</div>
+        <div class="horiz header">
+            <div class="horiz">
+                <div class="title"></div>
+                <div class="cycle-title-wrapper">
+                    <div class="cycle-title cycle-leaving"></div>
+                    <div class="cycle-title cycle-current"></div>
+                </div>
+            </div>
             <div class="tasks-count">0/0</div>
         </div>
         <div class="task-wrapper">

--- a/index.html
+++ b/index.html
@@ -21,10 +21,7 @@
         <div class="horiz header">
             <div class="horiz">
                 <div class="title"></div>
-                <div class="cycle-title-wrapper">
-                    <div class="cycle-title cycle-leaving"></div>
-                    <div class="cycle-title cycle-current"></div>
-                </div>
+                <div class="cycle-title"></div>
             </div>
             <div class="tasks-count">0/0</div>
         </div>

--- a/index.html
+++ b/index.html
@@ -19,9 +19,9 @@
 <body>
     <div class="main-content">
         <div class="horiz header">
-            <div class="horiz">
-                <div class="title"></div>
-                <div class="cycle-title"></div>
+            <div>
+                <div class="title">&nbsp;</div>
+                <div class="cycle-title">&nbsp;</div>
             </div>
             <div class="tasks-count">0/0</div>
         </div>

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -4,6 +4,7 @@
 let tasks = [];
 let scrolling = false;
 let animationStartTime = null;
+let nextCycleCommand = 0;
 
 // FONTS
 function loadGoogleFont(font) {
@@ -220,6 +221,49 @@ function infScrollAnimation(time) {
     } else {
         requestAnimationFrame(infScrollAnimation);
     }
+}
+
+function cycleCommandInHeader() {
+    if (!config.cycleCommands) {
+        return
+    }
+
+    const leavingTitle = document.querySelector(".cycle-title.cycle-leaving");
+    const currentTitle = document.querySelector(".cycle-title.cycle-current");
+    if (leavingTitle == null || currentTitle == null) {
+        console.error("missing cycle titles");
+        return;
+    }
+
+    leavingTitle.innerText = currentTitle.innerText;
+    leavingTitle.style.opacity = "100%";
+    currentTitle.style.opacity = "0%";
+    currentTitle.innerText = config.commandsToCycle[nextCycleCommand];
+    nextCycleCommand += 1;
+
+    let leavingKeyframes = [
+        {opacity: "100%"},
+        {opacity: "0%"},
+    ];
+    let enteringKeyframes = [
+        {opacity: "0%"},
+        {opacity: "100%"},
+    ];
+    let options = {
+        duration: config.fadeTime,
+        iterations: 1,
+        easing: "linear"
+    };
+
+    leaveAnimation = leavingTitle.animate(leavingKeyframes, options);
+    leaveAnimation.play();
+    leaveAnimation.addEventListener("finish", () => {
+        enterAnimation = currentTitle.animate(enteringKeyframes, options);
+        enterAnimation.play();
+        leaveAnimation.addEventListener("finish", () => {
+            window.setTimeout(cycleCommandInHeader, config.holdTime * 1000);
+        });
+    });
 }
 
 // TWITCH CHAT BOT
@@ -586,6 +630,15 @@ window.onload = function() {
         loadFonts();
         loadTasksDB();
 
+        // Setup static title, and determine header line count.
+        let staticTitle = document.querySelector(".title");
+        if (staticTitle != null) {
+            staticTitle.innerText = config.staticTitle;
+        }
+        static_lines = config.staticTitle.match('\n').length || 0;
+        cycle_lines = config.cycleTitle.match('\n').length || 0;
+        document.documentElement.style.setProperty("--header-lines", static_lines + cycle_lines);
+
         // Validate all commands accounted for.
         const commandConfig = {
             commandNames: config.commandNames,
@@ -628,6 +681,7 @@ window.onload = function() {
 
         saveTasksDB();
 
+        cycleCommandInHeader(); // does nothing if the cycling has been disabled
         renderDOM();
     } catch (error) {
         showErrorNotification(`${error} at ${error.stack[1]}`);

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -228,18 +228,11 @@ function cycleCommandInHeader() {
         return
     }
 
-    const leavingTitle = document.querySelector(".cycle-title.cycle-leaving");
-    const currentTitle = document.querySelector(".cycle-title.cycle-current");
-    if (leavingTitle == null || currentTitle == null) {
+    const cycleTitle = document.querySelector(".cycle-title");
+    if (cycleTitle == null) {
         console.error("missing cycle titles");
         return;
     }
-
-    leavingTitle.innerText = currentTitle.innerText;
-    leavingTitle.style.opacity = "100%";
-    currentTitle.style.opacity = "0%";
-    currentTitle.innerText = config.commandsToCycle[nextCycleCommand];
-    nextCycleCommand += 1;
 
     let leavingKeyframes = [
         {opacity: "100%"},
@@ -250,17 +243,20 @@ function cycleCommandInHeader() {
         {opacity: "100%"},
     ];
     let options = {
-        duration: config.fadeTime,
+        duration: config.fadeTime * 1000,
         iterations: 1,
         easing: "linear"
     };
 
-    leaveAnimation = leavingTitle.animate(leavingKeyframes, options);
+    leaveAnimation = cycleTitle.animate(leavingKeyframes, options);
     leaveAnimation.play();
     leaveAnimation.addEventListener("finish", () => {
-        enterAnimation = currentTitle.animate(enteringKeyframes, options);
+        cycleTitle.innerText = config.commandsToCycle[nextCycleCommand];
+        nextCycleCommand += 1;    
+
+        enterAnimation = cycleTitle.animate(enteringKeyframes, options);
         enterAnimation.play();
-        leaveAnimation.addEventListener("finish", () => {
+        enterAnimation.addEventListener("finish", () => {
             window.setTimeout(cycleCommandInHeader, config.holdTime * 1000);
         });
     });
@@ -635,8 +631,8 @@ window.onload = function() {
         if (staticTitle != null) {
             staticTitle.innerText = config.staticTitle;
         }
-        static_lines = config.staticTitle.match('\n').length || 0;
-        cycle_lines = config.cycleTitle.match('\n').length || 0;
+        static_lines = config.staticTitle.match('\n')?.length || 0;
+        cycle_lines = config.cycleTitle.match('\n')?.length || 0;
         document.documentElement.style.setProperty("--header-lines", static_lines + cycle_lines);
 
         // Validate all commands accounted for.

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -638,7 +638,7 @@ window.onload = function() {
         }
         static_lines = config.staticTitle.match('\n')?.length || 0;
         cycle_lines = config.cycleTitle.match('\n')?.length || 0;
-        document.documentElement.style.setProperty("--header-lines", static_lines + cycle_lines);
+        document.documentElement.style.setProperty("--header-lines", static_lines + cycle_lines + 1);
 
         // Validate all commands accounted for.
         const commandConfig = {

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -251,8 +251,11 @@ function cycleCommandInHeader() {
     leaveAnimation = cycleTitle.animate(leavingKeyframes, options);
     leaveAnimation.play();
     leaveAnimation.addEventListener("finish", () => {
-        cycleTitle.innerText = config.commandsToCycle[nextCycleCommand];
-        nextCycleCommand += 1;    
+        cycleTitle.innerText = config.cycleTitle
+            .replace("{command}", config.commandsToCycle[nextCycleCommand])
+            .replace(/^ +/g, "\u00A0")
+            .replace(/ +$/g, "\u00A0");
+        nextCycleCommand = (nextCycleCommand + 1) % config.commandsToCycle.length;   
 
         enterAnimation = cycleTitle.animate(enteringKeyframes, options);
         enterAnimation.play();
@@ -629,7 +632,9 @@ window.onload = function() {
         // Setup static title, and determine header line count.
         let staticTitle = document.querySelector(".title");
         if (staticTitle != null) {
-            staticTitle.innerText = config.staticTitle;
+            staticTitle.innerText = config.staticTitle
+                .replace(/^ +/g, "\u00A0")
+                .replace(/ +$/g, "\u00A0");
         }
         static_lines = config.staticTitle.match('\n')?.length || 0;
         cycle_lines = config.cycleTitle.match('\n')?.length || 0;

--- a/settings.js
+++ b/settings.js
@@ -19,6 +19,30 @@ const config = (() => {
     // If <=0, the task is removed instantly.
     const autoDeleteDelay = 1; // (seconds) any number >= 0. The delay after completing a task before it is deleted. If <=0, the task is removed instantly.
 
+    // The final title looks like:
+    // <static title><cycle title>
+    // e.g. with default settigns:
+    // To Do List | !task help
+
+    // The part of the title that doesn't change
+    // To add multiple lines to the title, DO NOT PRESS ENTER! That will BREAK THE FILE. Instead, type "\n" to insert a new line.
+    // example of newline: "To Do\nList" // add newline between Do and List.
+    const staticTitle = "To Do List | ";
+    // The part of the title that cycles through each command (shown after the static title)
+    // {command} is replaced with the command currently being shown
+    const cycleTitle = "{command}";
+    // Enables or disables the cycling of commands in the title. If disabled, `cycleTitle` is not shown.
+    const cycleCommands = true;
+    const holdTime = 5.0; // (seconds) How long to display a command for.
+    const fadeTime = 1.0; // (seconds) How long to fade in/out the previous/next commands.
+    // The list of commands to display in the title. Given as-is to `cycleTitle`.
+    const commandsToCycle = [
+        "!task help", // help
+        // task commands
+        "!task add", "!task done", "!task remove", "!task edit",
+        "!task credits", "!task github" // credits
+    ];
+
     // Names of different commands. Spaces allowed.
     // You can add multiple names for a single command, or just have one
     // The FIRST entry will be displayed in the help command as the primary command.
@@ -56,7 +80,6 @@ const config = (() => {
     // will not be required when passing a command to the help command.
     // i.e. "!task help task add" can be shortned to "!task help add".
 
-    // TODO: add support for "follower" role at some point (requires extra setup)
     // Valid permissions (from highest to lowest permissions): broadcaster, mod, sub, vip, everyone
     // For add, clear, help, credits, and reload: the permission level sets who can use the command
     // ... i.e if set to "vip", vips, subs, mods, and the broadcaster can use the command
@@ -120,6 +143,7 @@ const config = (() => {
     return {
         taskLimit, scrollingEnabled, scrollPxPerSecond, scrollPxGap, scrollLoopDelaySec, commandNames,
         autoDeleteDelay, autoDeleteCompletedTasks,
-        commandSyntaxes, commandDescriptions, commandPermissions
+        commandSyntaxes, commandDescriptions, commandPermissions,
+        staticTitle, cycleTitle, cycleCommands, holdTime, fadeTime, commandsToCycle,
     };
 })();

--- a/style_settings.css
+++ b/style_settings.css
@@ -28,5 +28,6 @@
 	--task-item-font-size: 20px; /* The size of each task item */
 	--error-font-size: 25px; /* The size of any displayed errors (like login failures) */
 
-	--header-lines: 1; /* The number of lines in the title text. */
+	/* ==================== */
+	--header-lines: 1; /* The number of lines in the title text. This is automatically set by the title in settings.js!  */
 }

--- a/styles/taskList.css
+++ b/styles/taskList.css
@@ -32,11 +32,6 @@ body {
 }
 
 .header {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-
     width: 100%;
     height: calc(max(calc(var(--title-font-size) * var(--header-lines)), var(--counter-font-size)) * 2);
 
@@ -50,9 +45,27 @@ body {
     background-color: var(--header-background-color);
 }
 
-.title {
+.horiz {
+	display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.title, .cycle-title {
     font-weight: bold;
     font-size: var(--title-font-size);
+}
+
+.cycle-title {
+	position: absolute;
+	top: 0;
+	left: 0;
+}
+
+.cycle-title-wrapper {
+	display: flex;
+	position: relative;
 }
 
 .tasks-count {

--- a/styles/taskList.css
+++ b/styles/taskList.css
@@ -57,17 +57,6 @@ body {
     font-size: var(--title-font-size);
 }
 
-.cycle-title {
-	position: absolute;
-	top: 0;
-	left: 0;
-}
-
-.cycle-title-wrapper {
-	display: flex;
-	position: relative;
-}
-
 .tasks-count {
     font-size: var(--counter-font-size);
 }

--- a/styles/taskList.css
+++ b/styles/taskList.css
@@ -46,13 +46,15 @@ body {
 }
 
 .horiz {
-	display: flex;
+    display: flex;
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
 }
 
 .title, .cycle-title {
+    display: inline;
+
     font-weight: bold;
     font-size: var(--title-font-size);
 }


### PR DESCRIPTION
Adds a new feature with paired settings to allow bot commands to be displayed in the title of the todo list and automatically cycle through a user-chosen set. This is also now the default behavior.

Steps left:
- [x] Test the code
- [x] Update README change list and last updated dates.

Implements and closes #7.