### PR TITLE
feat!: allow grouping tasks by username

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,35 @@ Inspired by [liyunze-coding/Chat-Task-Tic-Overlay](https://github.com/liyunze-co
 The latest changes since last time I pushed something to this repo:
 - Added new settings to give better control over the look of the header.
 - Added a feature to have the commands of the bot cycle in the title. See `settings.js` for details.
-- Improved the formatting of the code.
+- **MAJOR**: Added a new feature (on by default) to group tasks by username. This is a **breaking change**!
+  - Tasks are now grouped by username by default.
+  - Task numbers now only target your own tasks, and you can target other users tasks by added their names before the number.
+  - There's some extra style settings to control the new username headers.
+  - The old behavior can be restored by disabling `enableUsernameGrouping` in `settings.js`. This disables ALL of this features changes.
 
 ## List of commands
 
 - `!task help (command)`: List commands. Optionally, get help on a command.
 - `!task credits`: List bot credits.
-- `!task show <number>`: Shows a task and it's status in chat.
-- `!task add <task>`: Add a task to the list. Task can contain spaces.
-- `!task done <number>`: Finish a task.
-- `!task remove <number>`: Delete a task
-- `!task edit <number> <new-content>`: Edit a task to contain different text.
+- `!task show <@task>`: Shows a task and it's status in chat.
+- `!task add <task content...>`: Add a task to the list. Task can contain spaces.
+- `!task done <@task>`: Finish a task.
+- `!task remove <@task>`: Delete a task
+- `!task edit <@task> <new content...>`: Edit a task to contain different text.
 - `!task clear all`: Clear all tasks
 - `!task clear done`: Clear only fishised tasks.
 - `!task reload`: Reload bot and overlay.
-- `!task reassign <number> (user)`: Reassign a task to a new user. If the user is not given, reassign to yourself.
+- `!task reassign <@task> (user)`: Reassign a task to a new user. If the user is not given, reassign to yourself.
 - `!task github`: Display the bots github url.
+
+`<@task>` above means one of two things:
+- If username grouping is enabled: `[username] <number>`. Examples:
+    - `!task done 1` - Finish your first task.
+    - `!task done DamienPup 5` - Finish `DamienPup`'s 5th task.
+    - `!task reassign 2 JohnDoe` - Give your second task to `JohnDoe`.
+    - `!task reassign DamienPup 2 JohnDoe` - Give `DamienPup`'s second task to `JohnDoe`.
+- If username grupising is disabled: `<number>`.  Examples:
+    - `!task remove 3` - Delete the third task on the list.
 
 By default everyone can use `help`,  `credits` and `github`, `add` tasks, as well as finish (`done`), `remove`, and `edit` tasks they started. Mods can use `clear`, `reassign`, as well as finish (`done`), `remove`, and `edit` all tasks. Only the broadcaster can `reload` the bot. All of these permissions can be changed in `settings.js`.
 
@@ -60,9 +73,9 @@ By default everyone can use `help`,  `credits` and `github`, `add` tasks, as wel
 > The following files contain your settings. If updating from a previous version, do *not* replace these files unless they have been updated. If they have been updated, **migrate your settings to the new versions**.
 > You **will** have issues if you do not keep these updated.
 >
-> Last update to `settings.js`: 9af7ae1928ffb0949160ddf8e5fb6021e18b40de on May 24th, 2024.
+> Last update to `settings.js`: Commit a9191c9fe001f303cb4625a368c2a573bd546aa2 on May 30th, 2024.
 >
-> Last update to `style_settings.css`: Commit a215828d84f31034fae8b3279593d413835a9942 on May 23th, 2024.
+> Last update to `style_settings.css`: Commit 2711b1af202c72e93af3c015039bcf66c668895d on May 30th, 2024.
 >
 > Last update to `auth.js`: Commit b807cf384b231e0700130d6f0da875f5604d956b on Oct 18, 2023.
 >

--- a/index.html
+++ b/index.html
@@ -35,18 +35,9 @@
         <template id="task-template">
             <div class="task-item">
                 <div class="checkbox">
-                    <input
-                        type="checkbox"
-                        class="task-checkbox"
-                    /><label></label>
+                    <input type="checkbox" class="task-checkbox"/><label></label>
                 </div>
-                <!-- <div class="task-index">
-                0.
-            </div>
-            <div class="task-text">
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Corrupti, neque!
-            </div> -->
-                <div class="task-index">
+                <div class="task-text">
                     0. Lorem ipsum dolor sit amet consectetur adipisicing elit. Corrupti, neque!
                 </div>
             </div>

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -127,21 +127,43 @@ function renderDOM() {
         taskList.innerHTML = "";
     });
 
+    let userDivs = {};
+
     tasks.forEach((task, index) => {
         const taskElement = template.content.cloneNode(true);
 
-        //taskElement.querySelector(".task-index").textContent = `${index + 1} (${task.user}).`;
-        taskElement.querySelector(".task-index").textContent = `${index + 1}. ${task.user}: ${task.task}`;
-        //taskElement.querySelector(".task-text").textContent = task.task;
         taskElement.querySelector(".task-checkbox").checked = task.completed;
+        taskElement.querySelector(".task-text").classList.toggle("crossed", task.completed);
 
-        taskElement.querySelector(".task-index").classList.toggle("crossed", task.completed);
-        ///taskElement.querySelector(".task-text").classList.toggle("crossed", task.completed);
+        if (config.userGroupingEnabled) {
+            if (!(task.user in userDivs)) {
+                userDivs[task.user] = document.createElement("div");
 
-        taskLists.forEach(taskList => {
-            taskList.appendChild(taskElement.cloneNode(true));
-        });
+                let header = document.createElement("p");
+                header.innerText = task.user;
+                header.classList.add("title");
+                userDivs[task.user].appendChild(header);
+            }
+            
+            taskElement.querySelector(".task-text").textContent = `${index + 1}. ${task.task}`;
+
+            userDivs[task.user].appendChild(taskElement);
+        } else {
+            taskElement.querySelector(".task-text").textContent = `${index + 1}. ${task.user}: ${task.task}`;
+
+            taskLists.forEach(taskList => {
+                taskList.appendChild(taskElement.cloneNode(true));
+            });
+        }
     });
+
+    if (config.userGroupingEnabled) {
+        Object.values(userDivs).forEach(userDiv => {
+            taskLists.forEach(taskList => {
+                taskList.appendChild(userDiv.cloneNode(true));
+            });
+        });
+    }
 
     let totalTasks = tasks.length;
     let completedTasks = tasks.filter((value) => value.completed).length;

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -141,7 +141,7 @@ function renderDOM() {
 
                 let header = document.createElement("p");
                 header.innerText = task.user;
-                header.classList.add("title");
+                header.classList.add("task-username");
                 userDivs[task.user].appendChild(header);
             }
             

--- a/settings.js
+++ b/settings.js
@@ -3,6 +3,9 @@ const config = (() => {
     // Set to `null` or `undefined` to disable, or any postive whole number to set the limit.
     const taskLimit = null;
 
+    // Enable or disable grouping tasks by usernames:
+    const userGroupingEnabled = true;
+
     // Enable or disable scrolling. `true` or `false`.
     const scrollingEnabled = true;
     // The speed of scrolling in pixels per second. Can be any postive number. Will likely not work with negative numbers.
@@ -145,5 +148,6 @@ const config = (() => {
         autoDeleteDelay, autoDeleteCompletedTasks,
         commandSyntaxes, commandDescriptions, commandPermissions,
         staticTitle, cycleTitle, cycleCommands, holdTime, fadeTime, commandsToCycle,
+        userGroupingEnabled,
     };
 })();

--- a/settings.js
+++ b/settings.js
@@ -113,17 +113,20 @@ const config = (() => {
     // The default shows required parameters in <> and optional ones in ().
     // Options are shown using |.
     // Feel free to change the names of the parameters, but try to keep the general format the same so things aren't confusing.
+    const taskSyntaxUngrouped = "<number>"; // The format to access tasks when grouping is disabled
+    const taskSyntaxGrouped = "(username) <number>"; // The format to access tasks when grouped is enabled (added optional username argument to allow access to other users tasks for moderation purposes)
+    const taskSyntax = userGroupingEnabled ? taskSyntaxGrouped : taskSyntaxUngrouped; // don't touch this line
     const commandSyntaxes = {
-        show: "<number>",
+        show: `${taskSyntax}`,
         add: "<task>",
-        done: "<number>",
-        remove: "<number>",
-        edit: "<number> <new task>",
+        done: `${taskSyntax}`,
+        remove: `${taskSyntax}`,
+        edit: `${taskSyntax} <new task>`,
         clear: "<done|all>",
         help: "(command)",
         credits: "",
         reload: "",
-        reassign: "<number> (user)",
+        reassign: `${taskSyntax} (user)`,
         github: "",
     };
 

--- a/style_settings.css
+++ b/style_settings.css
@@ -4,6 +4,7 @@
       For now, any fonts used must be from: https://fonts.google.com/.
     */
     --header-font: "Fredoka One"; /* The font of the title and task counter */
+    --username-font: "Nunito"; /* The font of the usernames, when username grouping is enabled */
     --body-font: "Nunito"; /* The font of the task items */
 
     /*

--- a/style_settings.css
+++ b/style_settings.css
@@ -15,6 +15,7 @@
     --header-text-color: white; /* The text color of the title and task counter */
     --header-background-color: rgba(0, 0, 0, 0.9); /* The background of the title and task counter box */
     --task-list-background-color: rgba(0, 0, 0, 0.8); /* The background of the list of tasks */
+    --task-username-color: white; /* The task usernames, when username grouping is enabled */
     --task-item-text-color: white; /* The text color of the task items */
     --task-item-background-color: rgba(0, 0, 0, 0.8); /* The background color of each task item */
 
@@ -25,6 +26,7 @@
     */
     --title-font-size: 30px; /* The size of the title */
     --counter-font-size: 30px; /* The size of the task counter text */
+    --task-username-font-size: 25px; /* The size of usernames, when username grouping is enabled.  */
     --task-item-font-size: 20px; /* The size of each task item */
     --error-font-size: 25px; /* The size of any displayed errors (like login failures) */
 

--- a/styles/taskList.css
+++ b/styles/taskList.css
@@ -176,6 +176,7 @@ input[type="checkbox"]:checked + label:after {
 }
 
 .task-username {
+    font-family: var(--username-font);
     font-weight: bold;
     color: var(--task-username-color);
     font-size: var(--task-username-font-size);

--- a/styles/taskList.css
+++ b/styles/taskList.css
@@ -175,6 +175,12 @@ input[type="checkbox"]:checked + label:after {
     padding-inline: 5px;
 }
 
+.task-username {
+    font-weight: bold;
+    color: var(--task-username-color);
+    font-size: var(--task-username-font-size);
+}
+
 /* Error handling */
 
 .critical-error {

--- a/styles/taskList.css
+++ b/styles/taskList.css
@@ -171,7 +171,7 @@ input[type="checkbox"]:checked + label:after {
     transform: translateY(-4px);
 }
 
-.task-index {
+.task-text {
     padding-inline: 5px;
 }
 


### PR DESCRIPTION
## Changes
Added a feature to allow tasks to be grouped by username, along with a default enabled setting to toggle it.
Implements and closes #5.

## What's Left
- [x] Give dedicated styles and settings for username headers
- [x] Fix number ordering (mega breaking change)
- [x] Minor style settings updates

## Tasks
- [x] The PR title includes a type prefix like "feat: " or "bug: "
- [x] The PR title indicates if this is a breaking change (e.g. "feat!: ")
- [x] Implement the changes described in the PR.
- [x] Test the PR to ensure nothing is broken.
- [x] README.md has been updated to include the changes made by this PR.
- [x] README.md has been updated to indicate if `settings.js`, `style_settings.css`, or `auth.js` has changed functionally.