### PR TITLE
feat: show command shows all tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,24 @@ Inspired by [liyunze-coding/Chat-Task-Tic-Overlay](https://github.com/liyunze-co
 3. [Settings Files](#settings-files)
 4. [Install Instructions](#install-instructions)
     - [Manually Generating an OAuth Token](#manually-generating-an-oauth-token)
+    - [Minor Updates](#minor-updates)
 
 ## Latest changes
 
 The latest changes since last time I pushed something to this repo:
-- Added new settings to give better control over the look of the header.
 - Added a feature to have the commands of the bot cycle in the title. See `settings.js` for details.
 - **MAJOR**: Added a new feature (on by default) to group tasks by username. This is a **breaking change**!
   - Tasks are now grouped by username by default.
   - Task numbers now only target your own tasks, and you can target other users tasks by added their names before the number.
   - There's some extra style settings to control the new username headers.
   - The old behavior can be restored by disabling `enableUsernameGrouping` in `settings.js`. This disables ALL of this features changes.
+- `!task show` can now show all commands for you or another user, the task number is no longer required.
 
 ## List of commands
 
 - `!task help (command)`: List commands. Optionally, get help on a command.
 - `!task credits`: List bot credits.
-- `!task show <@task>`: Shows a task and it's status in chat.
+- `!task show [username] [task]`: Shows a task and it's status in chat, or shows all tasks for you or another user.
 - `!task add <task content...>`: Add a task to the list. Task can contain spaces.
 - `!task done <@task>`: Finish a task.
 - `!task remove <@task>`: Delete a task
@@ -48,7 +49,7 @@ The latest changes since last time I pushed something to this repo:
 - If username grupising is disabled: `<number>`.  Examples:
     - `!task remove 3` - Delete the third task on the list.
 
-By default everyone can use `help`,  `credits` and `github`, `add` tasks, as well as finish (`done`), `remove`, and `edit` tasks they started. Mods can use `clear`, `reassign`, as well as finish (`done`), `remove`, and `edit` all tasks. Only the broadcaster can `reload` the bot. All of these permissions can be changed in `settings.js`.
+By default everyone can use `help`, `credits` and `github`, `show` and `add` tasks, as well as finish (`done`), `remove`, and `edit` tasks they started. Mods can use `clear` and `reassign`, as well as finish (`done`), `remove`, and `edit` all tasks. Only the broadcaster can `reload` the bot. All of these permissions can be changed in `settings.js`.
 
 ## Settings Files
 
@@ -73,11 +74,14 @@ By default everyone can use `help`,  `credits` and `github`, `add` tasks, as wel
 > The following files contain your settings. If updating from a previous version, do *not* replace these files unless they have been updated. If they have been updated, **migrate your settings to the new versions**.
 > You **will** have issues if you do not keep these updated.
 >
-> Last update to `settings.js`: Commit a9191c9fe001f303cb4625a368c2a573bd546aa2 on May 30th, 2024.
+> For minor updates, see the [Minor Updates](#minor-updates) section.
 >
-> Last update to `style_settings.css`: Commit 2711b1af202c72e93af3c015039bcf66c668895d on May 30th, 2024.
+> Last **major** update to `settings.js`: Commit a9191c9 on May 30th, 2024.
+> Last *minor* update to `settings.js`: Commit 6c19327 on May 30th 2024.
 >
-> Last update to `auth.js`: Commit b807cf384b231e0700130d6f0da875f5604d956b on Oct 18, 2023.
+> Last **major** update to `style_settings.css`: Commit 2711b1a on May 30th, 2024.
+>
+> Last **major** update to `auth.js`: Commit b807cf3 on Oct 18, 2023.
 >
 > `CLIENT_ID.txt` does not need updates.
 >
@@ -113,3 +117,9 @@ https://id.twitch.tv/oauth2/authorize
 ```js
 const OAUTH_TOKEN = "YOUR_TOKEN_HERE";
 ```
+
+### Minor Updates
+
+1. Commit 6c19327 made a small change to `settings.js`. If updating from commit a9191c9 or later, simply change line 120 of `settings.js`:
+   - From: ```show: `${taskSyntax}`,```
+   - To: ```show: `[username] [number]`,```

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -588,16 +588,45 @@ function commandReassign(user, command, flags, extra) {
 }
 
 function commandShow(user, command, flags, extra) {
-    if (command.arguments.length < 1 || command.arguments.length > 2) {
+    if (command.arguments.length > 2) {
         return printCommandHelp(command);
     }
 
-    let {task, index} = cmdGetTask(user, command);
-    if (!task) {
-        return;
-    }
+    switch (command.arguments.length) {
+        case 0: // show all user tasks
+            let userTasks = [];
+            tasks.forEach(task => {
+                if (task.user != user) return;
 
-    return ComfyJS.Say(`${task.task}, started by ${task.user}, ${task.completed ? '' : 'not'} finished`);
+                let userTask = task.task;
+                if (task.completed) {
+                    userTask += " (finished)"
+                }
+                userTasks.push(userTask);
+            });
+            return ComfyJS.Say(`Your tasks: ${userTasks.join(", ")}`);
+        case 1: // show <username> OR show <index>
+            let username = command.arguments[0]
+            if (isNaN(parseInt(username))) { // show <username>
+                let userTasks = [];
+                tasks.forEach(task => {
+                    if (task.user != username) return;
+
+                    let userTask = task.task;
+                    if (task.completed) {
+                        userTask += " (finished)"
+                    }
+                    userTasks.push(userTask);
+                });
+                return ComfyJS.Say(`${username}'s tasks: ${userTasks.join(", ")}`);
+            }
+        case 2: // show <username> <index> OR (via fallthrough) show <index>
+            let {task, _} = cmdGetTask(user, command);
+            if (!task) {
+                return;
+            }
+            return ComfyJS.Say(`${task.task}, started by ${task.user}, ${task.completed ? '' : 'not'} finished`);
+    }
 }
 
 const commandFunctions = {

--- a/settings.js
+++ b/settings.js
@@ -117,7 +117,7 @@ const config = (() => {
     const taskSyntaxGrouped = "(username) <number>"; // The format to access tasks when grouped is enabled (added optional username argument to allow access to other users tasks for moderation purposes)
     const taskSyntax = userGroupingEnabled ? taskSyntaxGrouped : taskSyntaxUngrouped; // don't touch this line
     const commandSyntaxes = {
-        show: `${taskSyntax}`,
+        show: `[username] [number]`,
         add: "<task>",
         done: `${taskSyntax}`,
         remove: `${taskSyntax}`,


### PR DESCRIPTION
## Changes
It can now be used in these ways:
- `!task show` shows all tasks for your user.
- `!task show <username>` shows all tasks for the given user.
- `!task show <number>` shows the given task, following user grouping rules.
- `!task show <username> <number>` shows the given task for the given user, if user grouping is enabled. Otherwise it errors.
Fixes #10.

## Tasks
- [x] The PR title includes a type prefix like "feat: " or "bug: "
- [x] The PR title indicates if this is a breaking change (e.g. "feat!: ")
- [x] Implement the changes described in the PR.
- [x] Test the PR to ensure nothing is broken.
- [x] README.md has been updated to include the changes made by this PR.
- [x] README.md has been updated to indicate if `settings.js`, `style_settings.css`, or `auth.js` has changed functionally.